### PR TITLE
CI: Fix set flag bug

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -65,7 +65,7 @@ jobs:
         wget -O boot-source.img ${{ env.SOURCE_BOOT_IMAGE }}
         if [ -f boot-source.img ]; then
             echo "FORMAT_MKBOOTING=$(echo `tools/unpack_bootimg.py --boot_img=boot-source.img --format mkbootimg`)" >> $GITHUB_ENV
-            echo "HAVE_SOURCE_BOOT_IMAGE=true"
+            echo "HAVE_SOURCE_BOOT_IMAGE=true" >> $GITHUB_ENV
         else
             echo "Source boot image is empty"
         fi


### PR DESCRIPTION
HAVE_SOURCE_BOOT_IMAGE=true should be dropped in GITHUB_ENV.
Or it will skip make boot image unconditionally.