### PR TITLE
CI: don't check event sender

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Build Kernel by ${{ github.actor }}
     runs-on: ubuntu-latest
-    if: github.event.repository.owner.id == github.event.sender.id
     steps:
     - uses: actions/checkout@v3
     - name: Setup Configuration


### PR DESCRIPTION
If you want others to use stared to start actions, event sender judgment should be removed. Or the actions will be Skipped.
The same is true if you use corn.
