### PR TITLE
CI: Disable KPROBES when building without KPROBES and CC_WERROR

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -124,6 +124,11 @@ jobs:
             echo "CONFIG_KPROBES=y" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
             echo "CONFIG_HAVE_KPROBES=y" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
             echo "CONFIG_KPROBE_EVENTS=y" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
+        else
+            sed -i 's/CONFIG_KPROBES=y/CONFIG_KPROBES=n/' arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
+            sed -i 's/CONFIG_CC_WERROR=y/CONFIG_CC_WERROR=n/' arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
+            echo "CONFIG_KPROBES=n" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
+            echo "CONFIG_CC_WERROR=n" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}
         fi
         if [ ${{ env.USE_OVERLAYFS }} = true ]; then
             echo "CONFIG_OVERLAY_FS=y" >> arch/${{ env.TARGET_ARCH }}/configs/${{ env.KERNEL_DEFCONFIG }}


### PR DESCRIPTION
* Disabling CC_WERROR when building without KPROBES prevents the following kernel compilation issues:

  /home/builder/paper-work/other-ksu/xm-msm8998/drivers/kernelsu/ksu.c:60:2: error: ("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html") [-Werror,-W#warnings] warning("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html") ^ 1 error generated.

* Some kernels enable KPROBES[1] by default, and disable it if USE_KPROBES(=false) is not used.

[1]: github.com/LineageOS/android_kernel_xiaomi_msm8998/commit/7384a7dd

Change-Id: Ia08fcbf49125c0f47a9b26679b2490c7bf7b7290