### PR TITLE
Fix as -EF error

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -117,6 +117,11 @@ jobs:
             echo "HAVE_SOURCE_BOOT_IMAGE=true" >> $GITHUB_ENV
         fi
   
+    - name: Install aarch64-linux-gnu
+      run: |
+        sudo apt install aarch64-linux-gnu
+        export PATH=/usr/aarch64-linux-gnu/bin/:$PATH:/usr/lib/gcc/x86_64-linux-gnu/9:/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
+  
     - name: Setup KernelSU
       if: env.ENABLE_KERNELSU == 'true'
       run: |

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -119,7 +119,7 @@ jobs:
   
     - name: Install aarch64-linux-gnu
       run: |
-        sudo apt install aarch64-linux-gnu
+        sudo apt-get install aarch64-linux-gnu
         export PATH=/usr/aarch64-linux-gnu/bin/:$PATH:/usr/lib/gcc/x86_64-linux-gnu/9:/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
   
     - name: Setup KernelSU

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -120,7 +120,7 @@ jobs:
     - name: Install aarch64-linux-gnu
       run: |
         sudo apt-get install gcc-aarch64-linux-gnu
-        export PATH=/usr/aarch64-linux-gnu/bin/:$PATH:/usr/lib/gcc/x86_64-linux-gnu/9:/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
+        export PATH=/usr/aarch64-linux-gnu/bin/:/usr/lib/gcc/x86_64-linux-gnu/9:/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper:$PATH
   
     - name: Setup KernelSU
       if: env.ENABLE_KERNELSU == 'true'

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -119,7 +119,7 @@ jobs:
   
     - name: Install aarch64-linux-gnu
       run: |
-        sudo apt-get install aarch64-linux-gnu
+        sudo apt-get install gcc-aarch64-linux-gnu
         export PATH=/usr/aarch64-linux-gnu/bin/:$PATH:/usr/lib/gcc/x86_64-linux-gnu/9:/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
   
     - name: Setup KernelSU

--- a/config.env
+++ b/config.env
@@ -1,6 +1,6 @@
 KERNEL_SOURCE=https://github.com/MiCode/Xiaomi_Kernel_OpenSource/
 KERNEL_SOURCE_BRANCH=merlin-r-oss
-KERNEL_CONFIG=arch/arm64/configs/defconfig
+KERNEL_CONFIG=defconfig
 KERNEL_IMAGE_NAME=Image.gz
 ARCH=arm64
 EXTRA_CMDS:LD=ld.lld

--- a/config.env
+++ b/config.env
@@ -1,7 +1,7 @@
-KERNEL_SOURCE=https://github.com/xiaoleGun/android_kernel_xiaomi_wayne-4.19
-KERNEL_SOURCE_BRANCH=twrp-12
-KERNEL_CONFIG=vendor/wayne_defconfig
-KERNEL_IMAGE_NAME=Image.gz-dtb
+KERNEL_SOURCE=https://github.com/MiCode/Xiaomi_Kernel_OpenSource/
+KERNEL_SOURCE_BRANCH=merlin-r-oss
+KERNEL_CONFIG=arch/arm64/configs/defconfig
+KERNEL_IMAGE_NAME=Image.gz
 ARCH=arm64
 EXTRA_CMDS:LD=ld.lld
 
@@ -23,8 +23,8 @@ ENABLE_GCC_ARM64=true
 ENABLE_GCC_ARM32=true
 
 # KernelSU flags
-ENABLE_KERNELSU=false
-KERNELSU_TAG=main
+ENABLE_KERNELSU=true
+KERNELSU_TAG=
 KSU_EXPECTED_SIZE=
 KSU_EXPECTED_HASH=
 
@@ -41,5 +41,5 @@ ENABLE_CCACHE=true
 NEED_DTBO=false
 
 # Build boot images
-BUILD_BOOT_IMG=false
-SOURCE_BOOT_IMAGE=https://raw.githubusercontent.com/xiaoleGun/KernelSU_action/main/boot/boot.img
+BUILD_BOOT_IMG=true
+SOURCE_BOOT_IMAGE=https://bigota.d.miui.com/V13.0.1.0.SJOCNXM/merlin_images_V13.0.1.0.SJOCNXM_20220607.0000.00_12.0_cn_51efaee93c.tgz

--- a/config.env
+++ b/config.env
@@ -1,4 +1,4 @@
-KERNEL_SOURCE=https://github.com/MiCode/Xiaomi_Kernel_OpenSource/
+KERNEL_SOURCE=https://github.com/yuitoTDF/Kernel_Src
 KERNEL_SOURCE_BRANCH=merlin-r-oss
 KERNEL_CONFIG=defconfig
 KERNEL_IMAGE_NAME=Image.gz


### PR DESCRIPTION
我在[#72 ](https://github.com/xiaoleGun/KernelSU_Action/issues/72#issue-1825909285)提出了在某些情况下Build出现 as 的“未知选项 -EF”的问题。

该问题是由于/usr/bin/as并不支持-EF选项。

然而，aarch64-linux-gnu中附带的/usr/aarch64-linux-gnu/bin/as支持该选项。

于是，我在仓库的.github/workflows/build-kernel.yml增加了一段代码，用于安装aarch64-linux-gnu，以及设置$PATH。

然后，该问题得到解决。