### PR TITLE
README: KernelSU 1.0 no longer supports non-GKI kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ Fork 本仓库到你的储存库然后按照以下内容编辑 config.env，之�
 
 #### KernelSU Branch or Tag
 
+[KernelSU 1.0 已经不再支持非 GKI 内核](https://github.com/tiann/KernelSU/issues/1705)，最后的支持版本为 [v0.9.5](https://github.com/tiann/KernelSU/tree/v0.9.5)，请注意使用正确的分支
+
 选择 KernelSU 的分支或 tag:
 
-- main 分支(开发版): `KERNELSU_TAG=main`
-- 最新 TAG(稳定版): `KERNELSU_TAG=`
+- ~~main 分支(开发版): `KERNELSU_TAG=main`~~
+- 最新 TAG(稳定版): `KERNELSU_TAG=v0.9.5`
 - 指定 TAG(如`v0.5.2`): `KERNELSU_TAG=v0.5.2`
 
 #### KernelSU Manager signature size and hash

--- a/README_EN.md
+++ b/README_EN.md
@@ -119,10 +119,12 @@ Enable KernelSU for troubleshooting kernel failures or compiling the kernel sepa
 
 #### KernelSU Branch or Tag
 
+[KernelSU 1.0 no longer supports non-GKI kernels](https://github.com/tiann/KernelSU/issues/1705). The last supported version is [v0.9.5](https://github.com/tiann/KernelSU/tree/v0.9.5), please make sure to use the correct branch.
+
 Select the branch or tag of KernelSU:
 
-- main branch (development version): `KERNELSU_TAG=main`
-- Latest TAG (stable version): `KERNELSU_TAG=`
+- ~~main branch (development version): `KERNELSU_TAG=main`~~
+- Latest TAG (stable version): `KERNELSU_TAG=v0.9.5`
 - Specify the TAG (such as `v0.5.2`): `KERNELSU_TAG=v0.5.2`
 
 #### KernelSU Manager signature size and hash

--- a/config.env
+++ b/config.env
@@ -35,7 +35,7 @@ CUSTOM_GCC_32_BIN=arm-linux-androideabi-
 
 # KernelSU flags
 ENABLE_KERNELSU=false
-KERNELSU_TAG=main
+KERNELSU_TAG=v0.9.5
 KSU_EXPECTED_SIZE=
 KSU_EXPECTED_HASH=
 


### PR DESCRIPTION
The last supported version is v0.9.5, please make sure to use the correct branch. https://github.com/tiann/KernelSU/commit/898e9d4f8ca9b2f46b0c6b36b80a872b5b88d899