### PR TITLE
fix: temporarily fix of `python2 not found`

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: Build Kernel by ${{ github.actor }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CCACHE_COMPILERCHECK: "%compiler% -dumpmachine; %compiler% -dumpversion"
       CCACHE_NOHASHDIR: "true"


### PR DESCRIPTION
fix: temporarily fix of `python2 not found` because [ubuntu-latest change from 22.04.5 to 24.04.1](https://github.com/actions/runner-images/issues/10636) which drop python2