### PR TITLE
Use pypy instead of python2

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: Build Kernel by ${{ github.actor }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       CCACHE_COMPILERCHECK: "%compiler% -dumpmachine; %compiler% -dumpversion"
       CCACHE_NOHASHDIR: "true"
@@ -88,8 +88,10 @@ jobs:
         echo "BUILD_TIME=$(TZ=Asia/Shanghai date "+%Y%m%d%H%M")" >> $GITHUB_ENV
         echo "DEVICE=$(echo ${{ env.KERNEL_CONFIG }} | sed 's!vendor/!!;s/_defconfig//;s/_user//;s/-perf//')" >> $GITHUB_ENV
         sudo apt-get update
-        sudo apt-get install git ccache automake flex lzop bison gperf build-essential zip curl zlib1g-dev g++-multilib libxml2-utils bzip2 libbz2-dev libbz2-1.0 libghc-bzlib-dev squashfs-tools pngcrush schedtool dpkg-dev liblz4-tool make optipng maven libssl-dev pwgen libswitch-perl policycoreutils minicom libxml-sax-base-perl libxml-simple-perl bc libc6-dev-i386 lib32ncurses5-dev libx11-dev lib32z-dev libgl1-mesa-dev xsltproc unzip device-tree-compiler python2 python3
+        sudo apt-get install git ccache automake flex lzop bison gperf build-essential zip curl zlib1g-dev g++-multilib libxml2-utils bzip2 libbz2-dev libbz2-1.0 libghc-bzlib-dev squashfs-tools pngcrush schedtool dpkg-dev liblz4-tool make optipng maven libssl-dev pwgen libswitch-perl policycoreutils minicom libxml-sax-base-perl libxml-simple-perl bc libc6-dev-i386 lib32ncurses5-dev libx11-dev lib32z-dev libgl1-mesa-dev xsltproc unzip device-tree-compiler pypy python3
         mkdir -p $GITHUB_WORKSPACE/kernel_workspace
+        sudo ln -s /usr/bin/pypy /usr/bin/python
+        sudo ln -s /usr/bin/pypy /usr/bin/python2        
 
     - name: Download Clang-aosp
       if: env.USE_CUSTOM_CLANG != 'true'


### PR DESCRIPTION
ref:

user@localhost ~> pypy mkdtboimg.py
usage: mkdtboimg.py [-h] {create,cfg_create,dump,help} ...
mkdtboimg.py: error: too few arguments
user@localhost ~ [2]> pypy mkdtboimg.py -h
usage: mkdtboimg.py [-h] {create,cfg_create,dump,help} ...

optional arguments:
  -h, --help            show this help message and exit

subcommand:
  Valid subcommands

  {create,cfg_create,dump,help}
user@localhost ~> pypy
Python 2.7.12 (5.6.0+dfsg-4, Nov 20 2016, 10:45:22)
[PyPy 5.6.0 with GCC 6.2.0 20161109] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>>>